### PR TITLE
Filter py versions

### DIFF
--- a/tools/metatoenv.py
+++ b/tools/metatoenv.py
@@ -151,40 +151,30 @@ def _jinja_filter(dependencies, platform, pyversion):
                     raise RuntimeError("Bad preprocessing selector: "
                                        "unmatched square brackets or closing bracket "
                                        "found before opening bracket: {}".format(key))
-                selector = key[left:right + 1].replace('64', '').replace('32', '')
-                # Check for python version
+                selector = key[left:right + 1]
                 raw_selector = selector.lstrip('[ ').rstrip(' ]').replace(
-                    'python', 'py')
+                    'python', 'py').replace('64', '').replace('32', '')
+
                 if raw_selector.startswith('py'):
+                    # Check for python version
                     select_ver = raw_selector.replace('>',
                                                       '=').replace('<',
                                                                    '=').split('=')[-1]
                     select_op = raw_selector.replace('py', '').replace(select_ver,
                                                                        '').strip()
-                    print('select_ver', select_ver)
-                    print('select_op', select_op)
                     if select_ver.count('.') == 0:
                         select_ver = f'{select_ver[0]}.{select_ver[1:]}'
-                    print('select_ver2', select_ver)
                     if pyversion.count('.') == 0:
                         pyversion = f'{pyversion[0]}.{pyversion[1:]}'
                     if not ops[select_op](version.parse(pyversion),
                                           version.parse(select_ver)):
                         ok = False
-                    print(version.parse(pyversion), version.parse(select_ver))
-                    print(version.parse(pyversion) > version.parse(select_ver))
-
                 else:
                     # Check for platform
-                    if selector.startswith('[not'):
-                        # if (platform in selector) or (selector.replace(
-                        #         '[not', '')[:-1].strip() in platform):
-                        if platform in selector:
-                            ok = False
+                    if platform in raw_selector:
+                        ok = not raw_selector.startswith('not')
                     else:
-                        # if (platform not in selector) and (selector[1:-1] not in platform):
-                        if platform not in selector:
-                            ok = False
+                        ok = raw_selector.startswith('not')
 
                 if ok:
                     key = key.replace(selector, '').strip(' \n')

--- a/tools/metatoenv.py
+++ b/tools/metatoenv.py
@@ -133,7 +133,7 @@ def _parse_py_version(ver):
     `3.8`.
     Return a version parsed through the `packaging.version` tool.
     """
-    if (len(ver) > 1) and (ver.count('.') == 0):
+    if (len(ver) > 1) and '.' not in ver:
         ver = f'{ver[0]}.{ver[1:]}'
     return version.parse(ver)
 

--- a/tools/metatoenv.py
+++ b/tools/metatoenv.py
@@ -157,11 +157,8 @@ def _jinja_filter(dependencies, platform, pyversion):
 
                 if raw_selector.startswith('py'):
                     # Check for python version
-                    select_ver = raw_selector.replace('>',
-                                                      '=').replace('<',
-                                                                   '=').split('=')[-1]
-                    select_op = raw_selector.replace('py', '').replace(select_ver,
-                                                                       '').strip()
+                    select_ver = re.split(r'<|>|\=', raw_selector)[-1]
+                    select_op = re.search(r'(<|>|\=)+', raw_selector)[0]
                     if select_ver.count('.') == 0:
                         select_ver = f'{select_ver[0]}.{select_ver[1:]}'
                     if pyversion.count('.') == 0:

--- a/tools/metatoenv.py
+++ b/tools/metatoenv.py
@@ -171,10 +171,11 @@ def _jinja_filter(dependencies, platform, pyversion):
                         ok = False
                 else:
                     # Check for platform
+                    is_not = raw_selector.startswith('not')
                     if platform in raw_selector:
-                        ok = not raw_selector.startswith('not')
+                        ok = not is_not
                     else:
-                        ok = raw_selector.startswith('not')
+                        ok = is_not
 
                 if ok:
                     key = key.replace(selector, '').strip(' \n')


### PR DESCRIPTION
This adds filtering on python version in addition to platforms.
For example:

```
requirements:
  build:
    - mantid [py==38]
```

Also simplified some convoluted logic on platform selection which was trying to handle `linux` and `linux64` cases. We are now just deleting `64` from the string to make checks simpler.